### PR TITLE
fix: deprecation on format_base class

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -18,7 +18,7 @@
 defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/course/format/lib.php');
 
-class format_tabtopics extends format_base {
+class format_tabtopics extends core_courseformat\base {
 
     /**
      * Returns true if this course format uses sections


### PR DESCRIPTION
Previous:
![image](https://github.com/catalyst/moodle-format_tabtopics/assets/9924643/a93e0417-4e91-4a4f-b785-06e54eddf59f)

After:
![image](https://github.com/catalyst/moodle-format_tabtopics/assets/9924643/29f5f2b0-c59a-43f5-af63-54027df892db)

Deprecated since 4.0 - https://tracker.moodle.org/browse/MDL-71863