### PR TITLE
Make section li styling class specific

### DIFF
--- a/tabtop.css
+++ b/tabtop.css
@@ -54,7 +54,7 @@
     margin-bottom: 1px; /* for overlap (mapped to tabview-list border-width) */
 }
 
-ul.sectionul li
+ul.sectionul li.section
 {
     list-style-type: none;
 }


### PR DESCRIPTION
Basically the css for `ul.sectionul li` is too loose and any `li` element in the section summary is missing the bullet points.

![2024-06-24_14-29](https://github.com/catalyst/moodle-format_tabtopics/assets/13444485/cf953f88-2c68-40b9-be07-6ac42c1db425)
![2024-06-24_14-27](https://github.com/catalyst/moodle-format_tabtopics/assets/13444485/30c0cac1-1bd1-4ecb-9dbb-91ed1125463f)
