### PR TITLE
fix: make section content margin css rule more specific

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -15,7 +15,7 @@
 
 .course-content ul.topics {margin:0;}
 .course-content ul.topics li.section {list-style: none;margin:5px 0 0 0;padding:0;}
-.course-content ul.topics li.section .content {margin:0 40px;}
+.course-content ul.topics li.section .course-content-item-content {margin:0 40px;}
 .course-content ul.topics li.section .left {width:40px;float:left;text-align:center;}
 .course-content ul.topics li.section .right {width:40px;float:right;text-align:center;}
 .jumpmenu {text-align:center;}


### PR DESCRIPTION
In 4.5 activity icons now have a css class that represents the activity purpose, i.e. `MOD_PURPOSE_CONTENT` which is `content`.

Because of this the `.course-content ul.topics li.section .content` css rule is being applied to those icons. Looking at the container this rule is trying to target there is also a `course-content-item-content` class for it, so I've changed the rule to apply to that class instead.

This doesn't make format_tabtopics 4.5 compatible, there's some deeper changes that need to be made for that as it throws PHP errors, but this does stop the format messing with styles it shouldn't be.