### PR TITLE
Bugfixes for missing renderer functions with hidden sections

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -48,4 +48,13 @@ class renderer extends section_renderer {
     protected function page_title() {
         return get_string('topicoutline');
     }
+
+    /**
+     * Display a hidden section message
+     *
+     * @param type $section
+     */
+    public function section_hidden($section, $courseorid = null) {
+        echo parent::section_hidden($section, $courseorid);
+    }
 }

--- a/format.php
+++ b/format.php
@@ -91,10 +91,10 @@ if (!$PAGE->user_is_editing()) {
     $strgroups = get_string('groups');
     $strgroupmy = get_string('groupmy');
     $editing = $PAGE->user_is_editing();
-    $strtopichide = get_string('hidetopicfromothers');
-    $strtopicshow = get_string('showtopicfromothers');
-    $strmarkthistopic = get_string('markthistopic');
-    $strmarkedthistopic = get_string('markedthistopic');
+    $strtopichide = get_string('hidetopicfromothers', 'format_tabtopics');
+    $strtopicshow = get_string('showtopicfromothers', 'format_tabtopics');
+    $strmarkthistopic = get_string('markthistopic', 'format_tabtopics');
+    $strmarkedthistopic = get_string('markedthistopic', 'format_tabtopics');
     $strmoveup = get_string('moveup');
     $strmovedown = get_string('movedown');
 

--- a/format.php
+++ b/format.php
@@ -91,15 +91,12 @@ if (!$PAGE->user_is_editing()) {
     $strgroups = get_string('groups');
     $strgroupmy = get_string('groupmy');
     $editing = $PAGE->user_is_editing();
-
-    if ($editing) {
-        $strtopichide = get_string('hidetopicfromothers');
-        $strtopicshow = get_string('showtopicfromothers');
-        $strmarkthistopic = get_string('markthistopic');
-        $strmarkedthistopic = get_string('markedthistopic');
-        $strmoveup = get_string('moveup');
-        $strmovedown = get_string('movedown');
-    }
+    $strtopichide = get_string('hidetopicfromothers');
+    $strtopicshow = get_string('showtopicfromothers');
+    $strmarkthistopic = get_string('markthistopic');
+    $strmarkedthistopic = get_string('markedthistopic');
+    $strmoveup = get_string('moveup');
+    $strmovedown = get_string('movedown');
 
     // If currently moving a file then show the current clipboard.
     // Not too sure what this does.

--- a/lang/en/format_tabtopics.php
+++ b/lang/en/format_tabtopics.php
@@ -40,6 +40,8 @@ $string['sectionname'] = 'Topic';
 $string['showalltopics'] = 'Show all topics';
 $string['showfromothers'] = 'Show topic';
 $string['showtopicfromothers'] = 'Show topic';
+$string['markedthistopic'] = 'This section is highlighted as the current section';
+$string['markthistopic'] = 'Highlight this section as the current section';
 
 $string['tabtopics_remember_last_tab_session'] = 'Return user to previous selected tab';
 $string['tabtopics_remember_last_tab_session_help'] = 'If yes user will return to previous selected tab instead of the first tab.';


### PR DESCRIPTION
The strings were moved to loading unconditionally to avoid a warning in some cases, and the section_hidden function on the renderer was moved to have a definition as the base_renderer implementation is protected.